### PR TITLE
Disable scheduled execution in terraform-drift-report

### DIFF
--- a/.github/workflows/terraform-drift-report.yaml
+++ b/.github/workflows/terraform-drift-report.yaml
@@ -4,8 +4,8 @@ name: Terraform Drift Detection Report
 on:
 
   # Run every day at 2 AM UTC
-  schedule:
-    - cron: "*/50 * * * *"
+  # schedule:
+  #   - cron: "*/50 * * * *"
 
   # Allow manual execution
   workflow_dispatch:


### PR DESCRIPTION
Comment out the scheduled cron job for the workflow.